### PR TITLE
Alternative for `releaseable?` that doesn't always evaluate to `true`.

### DIFF
--- a/src/uncomplicate/commons/core.clj
+++ b/src/uncomplicate/commons/core.clj
@@ -151,7 +151,10 @@
       (not (identical? @obj-impl (find-protocol-impl Releasable this))))))
 
 (defn releaseable?
-  "Checks whether this is releaseable (in terms of Releaseable protocol)."
+  "Checks whether this is releaseable (in terms of Releaseable protocol).
+
+   Note: pending redefinitions of the `Releaseable` protocol, this function always returns true.
+   consider `nontrivially-releaseable?` for checking for non-default implementations."
   [this]
   (satisfies? Releaseable this))
 

--- a/src/uncomplicate/commons/core.clj
+++ b/src/uncomplicate/commons/core.clj
@@ -141,6 +141,15 @@
   "
   (release [this] "Releases all resources held by this object."))
 
+(let [obj-impl (delay (find-protocol-impl Releaseable (Object.)))]
+  "Checks whether the implementation of Releaseable for `this` isn't
+   identical to the catch-all implementations for `nil` and `Object`."
+  (defn nontrivially-releaseable?
+    [this]
+    (and
+      (some? this)
+      (not (identical? @obj-impl (find-protocol-impl Releasable this))))))
+
 (defn releaseable?
   "Checks whether this is releaseable (in terms of Releaseable protocol)."
   [this]


### PR DESCRIPTION
Due to how `satisfies?` works and due to `Object` and `nil` implementations being defined for `Release`, `release?` effectively is a clone of `any?` under any sensible circumstances.

Simply altering `releaseable?` is a breaking change, so this pull request introduces a `nontrivially-releaseable?` fn which checks if the object isn't `nil` and if its implementation is different from `Object`'s and a note about it in `release?`'s docs.
